### PR TITLE
V2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         operating-system: [ ubuntu-latest ]
-        php: [ '7.4', '8.0', '8.1', '8.2' ]
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
         dependencies: [ 'lowest', 'highest' ]
         exclude:
           - php: '8.1'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         operating-system: [ ubuntu-latest ]
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         dependencies: [ 'lowest', 'highest' ]
         exclude:
           - php: '8.1'
@@ -50,7 +50,7 @@ jobs:
           vendor/bin/phpunit --configuration phpunit.xml.dist --coverage-text --coverage-clover build/logs/clover.xml
 
       - name: Code coverage upload to Coveralls
-        if: matrix.php == '8.1' && matrix.dependencies == 'highest'
+        if: matrix.php == '8.3' && matrix.dependencies == 'highest'
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
 
       - uses: ramsey/composer-install@v2
         with:

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
 
       - uses: ramsey/composer-install@v2
         with:

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         operating-system: [ ubuntu-latest ]
-        php: [ '7.4', '8.0', '8.1', '8.2' ]
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
         dependencies: [ 'highest' ]
 
     name: PHP ${{ matrix.php }} on ${{ matrix.operating-system }} with ${{ matrix.dependencies }} dependencies

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         operating-system: [ ubuntu-latest ]
-        php: [ '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         dependencies: [ 'highest' ]
 
     name: PHP ${{ matrix.php }} on ${{ matrix.operating-system }} with ${{ matrix.dependencies }} dependencies

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
 
       - uses: ramsey/composer-install@v2
         with:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
 
       - uses: ramsey/composer-install@v2
         with:

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -44,7 +44,8 @@ return (new PhpCsFixer\Config())
         'global_namespace_import' => ['import_classes' => false, 'import_constants' => null, 'import_functions' => null],
 
         'no_empty_phpdoc' => true,
-        // 7.3 only 'no_superfluous_phpdoc_tags' => true,
+        'no_superfluous_phpdoc_tags' => true,
+
         'phpdoc_align' => true,
         'general_phpdoc_tag_rename' => true,
         'phpdoc_inline_tag_normalizer' => true,

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.x-dev"
+            "dev-master": "2.x-dev"
         }
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -51,12 +51,12 @@
     },
     "require": {
         "php": ">=7.4",
-        "doctrine/annotations": "< 1.14",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
         "zircote/swagger-php": "^4.5.3"
     },
     "require-dev": {
         "composer/package-versions-deprecated": "^1.11",
+        "doctrine/annotations": "^2.0",
         "friendsofphp/php-cs-fixer": "^2.17 || ^3.0",
         "phpstan/phpstan": "^1.6",
         "phpunit/phpunit": ">=8",

--- a/composer.json
+++ b/composer.json
@@ -57,9 +57,9 @@
     "require-dev": {
         "composer/package-versions-deprecated": "^1.11",
         "doctrine/annotations": "^2.0",
-        "friendsofphp/php-cs-fixer": "^2.17 || ^3.0",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "phpstan/phpstan": "^1.6",
-        "phpunit/phpunit": ">=8",
+        "phpunit/phpunit": "^9.0",
         "vimeo/psalm": "^4.23"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "require": {
         "php": ">=7.4",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
-        "zircote/swagger-php": "^4.5.3"
+        "zircote/swagger-php": "^4.11.0"
     },
     "require-dev": {
         "composer/package-versions-deprecated": "^1.11",

--- a/src/Annotations/Middleware.php
+++ b/src/Annotations/Middleware.php
@@ -28,7 +28,10 @@ class Middleware extends OA\Attachable
      */
     public function allowedParents(): ?array
     {
-        return [OA\Operation::class, Controller::class];
+        return [
+            OA\Operation::class,
+            Controller::class,
+        ];
     }
 
     /**

--- a/tests/AnnotationsTest.php
+++ b/tests/AnnotationsTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Radebatz\OpenApi\Extras\Processors\MergeControllerDefaults;
 use Symfony\Component\Finder\Finder;
 
-class SpecTest extends TestCase
+class AnnotationsTest extends TestCase
 {
     use Concerns\ComparesSpecs;
     use Concerns\UsesAnnotations;
@@ -36,7 +36,7 @@ class SpecTest extends TestCase
     /**
      * @dataProvider specTestProvider
      */
-    public function testSpec(Generator $generator, Finder $finder): void
+    public function testAnnotations(Generator $generator, Finder $finder): void
     {
         $openapi = $generator
             ->addProcessor(new MergeControllerDefaults(), BuildPaths::class)

--- a/tests/Concerns/ComparesSpecs.php
+++ b/tests/Concerns/ComparesSpecs.php
@@ -13,7 +13,6 @@ trait ComparesSpecs
      *
      * @param array|OpenApi|\stdClass|string $actual     The generated output
      * @param array|OpenApi|\stdClass|string $expected   The specification
-     * @param string                         $message
      * @param bool                           $normalized flag indicating whether the inputs are already normalized or
      *                                                   not
      */

--- a/tests/Fixtures/Controllers/Annotations/MiddlewareController.php
+++ b/tests/Fixtures/Controllers/Annotations/MiddlewareController.php
@@ -7,6 +7,7 @@ use Radebatz\OpenApi\Extras\Annotations as OAX;
 
 /**
  * @OAX\Controller(
+ *
  *     @OAX\Middleware(names={"Radebatz\OpenApi\Extras\Tests\Fixtures\Middleware\FooMiddleware"})
  * )
  */
@@ -16,7 +17,9 @@ class MiddlewareController
      * @OA\Get(
      *     path="/mw",
      *     operationId="mw",
+     *
      *     @OA\Response(response="200", description="All good"),
+     *
      *     @OAX\Middleware(names={"Radebatz\OpenApi\Extras\Tests\Fixtures\Middleware\BarMiddleware"})
      * )
      */

--- a/tests/Fixtures/Controllers/Annotations/PrefixedController.php
+++ b/tests/Fixtures/Controllers/Annotations/PrefixedController.php
@@ -8,6 +8,7 @@ use Radebatz\OpenApi\Extras\Annotations as OAX;
 /**
  * @OAX\Controller(
  *     prefix="/foo",
+ *
  *     @OA\Response(response="403", description="Not allowed")
  * )
  */
@@ -17,6 +18,7 @@ class PrefixedController
      * @OA\Get(
      *     path="/prefixed",
      *     operationId="prefixed",
+     *
      *     @OA\Response(response="200", description="All good")
      * )
      */

--- a/tests/Fixtures/OpenApi.php
+++ b/tests/Fixtures/OpenApi.php
@@ -9,6 +9,7 @@ use OpenApi\Annotations as OA;
  *     version="1.0",
  *     title="Example for response examples value",
  *     description="Example info",
+ *
  *     @OA\Contact(name="Swagger API Team")
  * )
  */


### PR DESCRIPTION
* Bumps version to `2.0.0`
* Bumps PHP deps to `7.4`
* Bumps swagger-php dep to 4.11.0 (required to make Attachable nesting work)
* Bumps pipeline tooling to using `8.3` where possible