### PR TITLE
OpenApiBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Introduction
-Re-useable annotations for [swagger-php](https://github.com/zircote/swagger-php).
+Extra attributes/annotations and other bits for [swagger-php](https://github.com/zircote/swagger-php).
 
 ## Installation
 
@@ -28,6 +28,21 @@ composer require radebatz/openapi-extras
 Use of the included annotations/attributes requires registration of a custom `swagger-php` processor.
 Also, in the case of annotations, the registration of custom aliases / namespaces needs to be done manually.
 
+### Using the Builder
+
+When using the `OpenApiBuilder` no additional registration code is required as the builder will always
+configure the required `MergeControllerDefaults` processor.
+
+```php
+<?php
+
+use Radebatz\OpenApi\Extras\OpenApiBuilder;
+
+$generator = (new OpenApiBuilder())->build();
+
+// ...
+```
+
 ### Register library for attributes
 
 ```php
@@ -38,7 +53,8 @@ use OpenApi\Processors\BuildPaths;
 use Radebatz\OpenApi\Extras\Processors\MergeControllerDefaults;
 
 $generator = new Generator();
-$generator->addProcessor(new MergeControllerDefaults(), BuildPaths::class);
+$generator->getProcessorPipeline()
+            ->insert(new MergeControllerDefaults(), BuildPaths::class);
 
 // ...
 ```
@@ -58,12 +74,35 @@ $generator = new Generator();
 $generator
     ->addNamespace($namespace . '\\')
     ->addAlias('oax', $namespace),
-    ->addProcessor(new MergeControllerDefaults(), BuildPaths::class);
+    ->getProcessorPipeline()
+    ->insert(new MergeControllerDefaults(), BuildPaths::class);
 
 // ...
 ```
 
 ## Basic usage
+
+### `OpenApiBuilder`
+
+The builder aims to simplify configuring the `swagger-php` `Generator` class by implementing
+explicit methods to configure all default processors.
+Futhermore, it also adds a new `Customizer` processor which allows to pre-process all instances
+of a given OpenApi annotation/attribute by registering callbacks.
+
+```php
+<?php declare(strict_types=1);
+
+use OpenApi\Annotations as OA;
+use Radebatz\OpenApi\Extras\OpenApiBuilder;
+
+$generator = (new OpenApiBuilder())
+                 ->addCustomizer(OA\Info::class, fn (OA\Info $info) => $info->description = 'Foo')
+                 ->tagsToMatch(['admin'])
+                 ->clearUnused(enabled: true)
+                 ->operationIdHashing(enabled: false)
+                 ->pathsToMatch(['/api'])
+                 ->build();
+```
 
 ### `Controller`
 

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
     "require": {
         "php": ">=7.4",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
-        "zircote/swagger-php": "^4.11.0"
+        "zircote/swagger-php": "^4.11.1"
     },
     "require-dev": {
         "composer/package-versions-deprecated": "^1.11",

--- a/src/OpenApiBuilder.php
+++ b/src/OpenApiBuilder.php
@@ -8,10 +8,6 @@ use Radebatz\OpenApi\Extras\Processors\Customizers;
 
 class OpenApiBuilder
 {
-    /**
-     * @var string|array
-     */
-    protected $paths = null;
     protected array $customizers = [];
     protected array $config = [];
 
@@ -27,7 +23,49 @@ class OpenApiBuilder
      */
     public function pathsToMatch($paths): OpenApiBuilder
     {
-        $this->paths = $paths;
+        $this->config['pathFilter'] = ['paths' => $paths];
+
+        return $this;
+    }
+
+    /**
+     * Only process endpoints matching the given `$tags` patterns.
+     *
+     * @param string|array $tags
+     */
+    public function tagsToMatch($tags): OpenApiBuilder
+    {
+        $this->config['pathFilter'] = ['tags' => $tags];
+
+        return $this;
+    }
+
+    /**
+     * Enable/disable cleaning up of unused components.
+     */
+    public function clearUnused(bool $enabled = true): OpenApiBuilder
+    {
+        $this->config['cleanUnusedComponents'] = ['enabled' => $enabled];
+
+        return $this;
+    }
+
+    /**
+     * Enable/disable hashing of operation ids.
+     */
+    public function operationIdHashing(bool $enabled = true): OpenApiBuilder
+    {
+        $this->config['operationId'] = ['hash' => $enabled];
+
+        return $this;
+    }
+
+    /**
+     * List og tags to keep even if unused.
+     */
+    public function tagWhitelist(array $whitelist): OpenApiBuilder
+    {
+        $this->config['augmentTags'] = ['whitelist' => $whitelist];
 
         return $this;
     }
@@ -54,10 +92,6 @@ class OpenApiBuilder
     {
         $generator = new Generator();
         $config = $this->config;
-
-        if ($this->paths) {
-            $config['pathFilter'] = ['paths' => $this->paths];
-        }
 
         if ($this->customizers) {
             $generator->getProcessorPipeline()

--- a/src/OpenApiBuilder.php
+++ b/src/OpenApiBuilder.php
@@ -13,6 +13,12 @@ class OpenApiBuilder
      */
     protected $paths = null;
     protected array $customizers = [];
+    protected array $config = [];
+
+    public function __construct(array $config = [])
+    {
+        $this->config = $config;
+    }
 
     /**
      * Only process endpoints matching the given `$paths` patterns.
@@ -46,8 +52,8 @@ class OpenApiBuilder
 
     public function build(): Generator
     {
-        $config = [];
         $generator = new Generator();
+        $config = $this->config;
 
         if ($this->paths) {
             $config['pathFilter'] = ['paths' => $this->paths];

--- a/src/OpenApiBuilder.php
+++ b/src/OpenApiBuilder.php
@@ -9,6 +9,9 @@ use Radebatz\OpenApi\Extras\Processors\Customizers;
 
 class OpenApiBuilder
 {
+    /**
+     * @var string|array
+     */
     protected $paths = null;
     protected array $customizers = [];
 

--- a/src/OpenApiBuilder.php
+++ b/src/OpenApiBuilder.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras;
+
+use InvalidArgumentException;
+use OpenApi\Annotations\AbstractAnnotation;
+use OpenApi\Generator;
+use Radebatz\OpenApi\Extras\Processors\Customizers;
+
+class OpenApiBuilder
+{
+    protected $paths = null;
+    protected array $customizers = [];
+
+    /**
+     * Only process endpoints matching the given `$paths` patterns.
+     *
+     * @param string|array $paths
+     */
+    public function pathsToMatch($paths): OpenApiBuilder
+    {
+        $this->paths = $paths;
+
+        return $this;
+    }
+
+    /**
+     * @param class-string<AbstractAnnotation> $class
+     */
+    public function addCustomizer(string $class, callable $customizer): OpenApiBuilder
+    {
+        if (!is_subclass_of($class, AbstractAnnotation::class)) {
+            throw new InvalidArgumentException(sprintf('Class "%s" must implement "%s".', $class, AbstractAnnotation::class));
+        }
+
+        if (!array_key_exists($class, $this->customizers)) {
+            $this->customizers[$class] = [];
+        }
+
+        $this->customizers[$class][] = $customizer;
+
+        return $this;
+    }
+
+    public function build(): Generator
+    {
+        $config = [];
+        $generator = new Generator();
+
+        if ($this->paths) {
+            $config['pathFilter'] = ['paths' => $this->paths];
+        }
+
+        if ($this->customizers) {
+            $generator->getProcessorPipeline()
+                ->add(new Customizers());
+            $config['customizers']['mappings'] = $this->customizers;
+        }
+
+        return $generator
+            ->setConfig($config);
+    }
+}

--- a/src/OpenApiBuilder.php
+++ b/src/OpenApiBuilder.php
@@ -2,7 +2,6 @@
 
 namespace Radebatz\OpenApi\Extras;
 
-use InvalidArgumentException;
 use OpenApi\Annotations\AbstractAnnotation;
 use OpenApi\Generator;
 use Radebatz\OpenApi\Extras\Processors\Customizers;
@@ -33,7 +32,7 @@ class OpenApiBuilder
     public function addCustomizer(string $class, callable $customizer): OpenApiBuilder
     {
         if (!is_subclass_of($class, AbstractAnnotation::class)) {
-            throw new InvalidArgumentException(sprintf('Class "%s" must implement "%s".', $class, AbstractAnnotation::class));
+            throw new \InvalidArgumentException(sprintf('Class "%s" must implement "%s".', $class, AbstractAnnotation::class));
         }
 
         if (!array_key_exists($class, $this->customizers)) {

--- a/src/OpenApiBuilder.php
+++ b/src/OpenApiBuilder.php
@@ -23,7 +23,11 @@ class OpenApiBuilder
      */
     public function pathsToMatch($paths): OpenApiBuilder
     {
-        $this->config['pathFilter'] = ['paths' => $paths];
+        if (!array_key_exists('pathFilter', $this->config)) {
+            $this->config['pathFilter'] = [];
+        }
+
+        $this->config['pathFilter']['paths'] = (array) $paths;
 
         return $this;
     }
@@ -35,7 +39,11 @@ class OpenApiBuilder
      */
     public function tagsToMatch($tags): OpenApiBuilder
     {
-        $this->config['pathFilter'] = ['tags' => $tags];
+        if (!array_key_exists('pathFilter', $this->config)) {
+            $this->config['pathFilter'] = [];
+        }
+
+        $this->config['pathFilter']['tags'] = (array) $tags;
 
         return $this;
     }

--- a/src/OpenApiBuilder.php
+++ b/src/OpenApiBuilder.php
@@ -4,8 +4,15 @@ namespace Radebatz\OpenApi\Extras;
 
 use OpenApi\Annotations\AbstractAnnotation;
 use OpenApi\Generator;
+use OpenApi\Processors\BuildPaths;
 use Radebatz\OpenApi\Extras\Processors\Customizers;
+use Radebatz\OpenApi\Extras\Processors\MergeControllerDefaults;
 
+/**
+ * A simple `builder` wrapper around the OpenApi `Generator` class.
+ *
+ * Provides explicit programmatic access to configuring the processors  of the `swagger-php` library.
+ */
 class OpenApiBuilder
 {
     protected array $customizers = [];
@@ -103,6 +110,7 @@ class OpenApiBuilder
 
         if ($this->customizers) {
             $generator->getProcessorPipeline()
+                ->insert(new MergeControllerDefaults(), BuildPaths::class)
                 ->add(new Customizers());
             $config['customizers']['mappings'] = $this->customizers;
         }

--- a/src/Processors/Customizers.php
+++ b/src/Processors/Customizers.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras\Processors;
+
+use OpenApi\Analysis;
+use OpenApi\Annotations\AbstractAnnotation;
+
+/**
+ * Allows to
+ */
+class Customizers
+{
+    protected array $mappings = [];
+
+    public function __construct(array $mappings = [])
+    {
+        $this->mappings = $mappings;
+    }
+
+    /**
+     * A map of annotation classnames to callables.
+     *
+     * The registered callables will get called for each instance of `classname` to allow to
+     * apply arbitrary customizations to the given instance.
+     *
+     * @param array<class-string<AbstractAnnotation>,callable> $mappings
+     */
+    public function setMappings(array $mappings): Customizers
+    {
+        $this->mappings = $mappings;
+
+        return $this;
+    }
+
+    public function getMappings(): array
+    {
+        return $this->mappings;
+    }
+
+    public function __invoke(Analysis $analysis)
+    {
+        foreach ($this->mappings as $classname => $callables) {
+            $annotations = $analysis->getAnnotationsOfType($classname);
+            foreach ($callables as $callable) {
+                foreach ($annotations as $annotation) {
+                    $callable($annotation);
+                }
+            }
+        }
+    }
+}

--- a/src/Processors/Customizers.php
+++ b/src/Processors/Customizers.php
@@ -6,7 +6,8 @@ use OpenApi\Analysis;
 use OpenApi\Annotations\AbstractAnnotation;
 
 /**
- * Allows to
+ * Allows for each annotation class to register one or more callbacks which
+ * then can modify each instance of that class.
  */
 class Customizers
 {

--- a/tests/OpenApiBuilderTest.php
+++ b/tests/OpenApiBuilderTest.php
@@ -87,7 +87,7 @@ class OpenApiBuilderTest extends TestCase
     public function testAddCustomizer(): void
     {
         $builder = (new OpenApiBuilder())
-            ->addCustomizer(OA\Info::class, fn() => true);
+            ->addCustomizer(OA\Info::class, fn () => true);
         $pipes = $this->getPipes($builder->build());
         $customizers = $this->getPipe($pipes, Customizers::class);
 
@@ -102,6 +102,6 @@ class OpenApiBuilderTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         (new OpenApiBuilder())
-            ->addCustomizer(\Exception::class, fn() => true);
+            ->addCustomizer(OA\Info::class, fn () => true);
     }
 }

--- a/tests/OpenApiBuilderTest.php
+++ b/tests/OpenApiBuilderTest.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class OpenApiBuilderTest extends TestCase
+{
+    public function testCustomizers() : void
+    {
+
+    }
+}

--- a/tests/OpenApiBuilderTest.php
+++ b/tests/OpenApiBuilderTest.php
@@ -102,6 +102,7 @@ class OpenApiBuilderTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         (new OpenApiBuilder())
-            ->addCustomizer(OA\Info::class, fn () => true);
+            // @phpstan-ignore-next-line
+            ->addCustomizer(\Exception::class, fn () => true);
     }
 }

--- a/tests/OpenApiBuilderTest.php
+++ b/tests/OpenApiBuilderTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class OpenApiBuilderTest extends TestCase
 {
-    public function testCustomizers() : void
+    public function testCustomizers(): void
     {
 
     }

--- a/tests/OpenApiBuilderTest.php
+++ b/tests/OpenApiBuilderTest.php
@@ -2,8 +2,8 @@
 
 namespace Radebatz\OpenApi\Extras\Tests;
 
-use OpenApi\Generator;
 use OpenApi\Annotations as OA;
+use OpenApi\Generator;
 use OpenApi\Processors\AugmentTags;
 use OpenApi\Processors\CleanUnusedComponents;
 use OpenApi\Processors\OperationId;
@@ -34,7 +34,7 @@ class OpenApiBuilderTest extends TestCase
         return null;
     }
 
-    public function testPathFilterConfig(): void
+    public function testPathFilterConfigMixed(): void
     {
         $builder = (new OpenApiBuilder())
             ->pathsToMatch('foo')
@@ -87,7 +87,7 @@ class OpenApiBuilderTest extends TestCase
     public function testAddCustomizer(): void
     {
         $builder = (new OpenApiBuilder())
-            ->addCustomizer(OA\Info::class, fn () => true);
+            ->addCustomizer(OA\Info::class, fn() => true);
         $pipes = $this->getPipes($builder->build());
         $customizers = $this->getPipe($pipes, Customizers::class);
 
@@ -95,5 +95,13 @@ class OpenApiBuilderTest extends TestCase
 
         $mappings = $customizers->getMappings();
         $this->assertCount(1, $mappings);
+    }
+
+    public function testAddCustomizerInvalidClass(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new OpenApiBuilder())
+            ->addCustomizer(\Exception::class, fn() => true);
     }
 }

--- a/tests/OpenApiBuilderTest.php
+++ b/tests/OpenApiBuilderTest.php
@@ -2,12 +2,98 @@
 
 namespace Radebatz\OpenApi\Extras\Tests;
 
+use OpenApi\Generator;
+use OpenApi\Annotations as OA;
+use OpenApi\Processors\AugmentTags;
+use OpenApi\Processors\CleanUnusedComponents;
+use OpenApi\Processors\OperationId;
+use OpenApi\Processors\PathFilter;
 use PHPUnit\Framework\TestCase;
+use Radebatz\OpenApi\Extras\OpenApiBuilder;
+use Radebatz\OpenApi\Extras\Processors\Customizers;
 
 class OpenApiBuilderTest extends TestCase
 {
-    public function testCustomizers(): void
+    protected function getPipes(Generator $generator): array
     {
+        $pipeline = $generator->getProcessorPipeline();
+        $rp = new \ReflectionProperty($pipeline, 'pipes');
+        $rp->setAccessible(true);
 
+        return $rp->getValue($pipeline);
+    }
+
+    protected function getPipe(array $pipes, string $pipeClass)
+    {
+        foreach ($pipes as $pipe) {
+            if ($pipe instanceof $pipeClass) {
+                return $pipe;
+            }
+        }
+
+        return null;
+    }
+
+    public function testPathFilterConfig(): void
+    {
+        $builder = (new OpenApiBuilder())
+            ->pathsToMatch('foo')
+            ->tagsToMatch(['bar']);
+        $pipes = $this->getPipes($builder->build());
+        $pathFilter = $this->getPipe($pipes, PathFilter::class);
+
+        $this->assertNotNull($pathFilter);
+        $this->assertEquals(['foo'], $pathFilter->getPaths());
+        $this->assertEquals(['bar'], $pathFilter->getTags());
+    }
+
+    public function testClearUnused(): void
+    {
+        $builder = (new OpenApiBuilder())
+            ->clearUnused(true);
+        $pipes = $this->getPipes($builder->build());
+        $cleanUnusedComponents = $this->getPipe($pipes, CleanUnusedComponents::class);
+
+        $this->assertNotNull($cleanUnusedComponents);
+        $this->assertTrue($cleanUnusedComponents->isEnabled());
+    }
+
+    public function testOperationIdHashing(): void
+    {
+        $builder = (new OpenApiBuilder())
+            ->operationIdHashing(false);
+        $pipes = $this->getPipes($builder->build());
+        $operationId = $this->getPipe($pipes, OperationId::class);
+
+        $this->assertNotNull($operationId);
+        $this->assertFalse($operationId->isHash());
+    }
+
+    public function testTagWhitelist(): void
+    {
+        $builder = (new OpenApiBuilder())
+            ->tagWhitelist(['ding']);
+        $pipes = $this->getPipes($builder->build());
+        $augmentTags = $this->getPipe($pipes, AugmentTags::class);
+
+        $this->assertNotNull($augmentTags);
+
+        $rp = new \ReflectionProperty($augmentTags, 'whitelist');
+        $rp->setAccessible(true);
+
+        $this->assertEquals(['ding'], $rp->getValue($augmentTags));
+    }
+
+    public function testAddCustomizer(): void
+    {
+        $builder = (new OpenApiBuilder())
+            ->addCustomizer(OA\Info::class, fn () => true);
+        $pipes = $this->getPipes($builder->build());
+        $customizers = $this->getPipe($pipes, Customizers::class);
+
+        $this->assertNotNull($customizers);
+
+        $mappings = $customizers->getMappings();
+        $this->assertCount(1, $mappings);
     }
 }

--- a/tests/Processors/CustomizersTest.php
+++ b/tests/Processors/CustomizersTest.php
@@ -17,9 +17,9 @@ class CustomizersTest extends TestCase
         $generator->setConfig([
             'customizers' => [
                 'mappings' => [
-                    OpenApi::class => [fn(OpenApi $openApi) => $openApi->openapi = OpenApi::VERSION_3_1_0],
-                ]
-            ]
+                    OpenApi::class => [fn (OpenApi $openApi) => $openApi->openapi = OpenApi::VERSION_3_1_0],
+                ],
+            ],
         ]);
 
         $openapi = $generator->generate([__DIR__ . '/../Fixtures/OpenApi.php']);

--- a/tests/Processors/CustomizersTest.php
+++ b/tests/Processors/CustomizersTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras\Tests\Processors;
+
+use OpenApi\Annotations\OpenApi;
+use OpenApi\Generator;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Radebatz\OpenApi\Extras\Processors\Customizers;
+
+class CustomizersTest extends TestCase
+{
+    public function testMappings(): void
+    {
+        $generator = new Generator(new NullLogger());
+        $generator->getProcessorPipeline()->add(new Customizers());
+        $generator->setConfig([
+            'customizers' => [
+                'mappings' => [
+                    OpenApi::class => [fn(OpenApi $openApi) => $openApi->openapi = OpenApi::VERSION_3_1_0],
+                ]
+            ]
+        ]);
+
+        $openapi = $generator->generate([__DIR__ . '/../Fixtures/OpenApi.php']);
+
+        $this->assertEquals(OpenApi::VERSION_3_1_0, $openapi->openapi);
+    }
+}


### PR DESCRIPTION
Adds the `OpenApiBuilder` class that:
* wraps some of the more useful processor options programmatically
* adds a new `Customizers` processor that allows to register custom callables to modify all annotations of a specifc type