### PR TITLE
Fix branch alias `dev-master` -> `dev-main`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-main": "2.x-dev"
         }
     },
     "require": {


### PR DESCRIPTION
- switch to using openapi-extras instead of own custom annotations
- bump PHP requirements to 8.1
- update build matrix and use PHP 8.3 for tooling where possible

Fixes https://github.com/DerManoMann/openapi-router/issues/29