### PR TITLE
Add support for `swagger-php` v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "php": ">=8.1",
         "psr/log": "^2.0 || ^3.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
-        "zircote/swagger-php": "^4.11.1 || ^5.0"
+        "zircote/swagger-php": "^4.11.1 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "composer/package-versions-deprecated": "^1.11",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         "php": ">=8.1",
         "psr/log": "^2.0 || ^3.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
-        "zircote/swagger-php": "^4.11.1 || ^5.0 || ^6.0"
+        "zircote/swagger-php": "^4.11.1 || ^5.0 || ^6.0.3"
     },
     "require-dev": {
         "composer/package-versions-deprecated": "^1.11",

--- a/src/OpenApiBuilder.php
+++ b/src/OpenApiBuilder.php
@@ -61,9 +61,19 @@ class OpenApiBuilder
     }
 
     /**
+     * Enable/disable recursive cleanup of unused paths and their nested annotations.
+     */
+    public function clearUnusedPaths(bool $enabled = true): OpenApiBuilder
+    {
+        $this->config['pathFilter'] = ['recurseCleanup' => $enabled];
+
+        return $this;
+    }
+
+    /**
      * Enable/disable cleaning up of unused components.
      */
-    public function clearUnused(bool $enabled = true): OpenApiBuilder
+    public function clearUnusedComponents(bool $enabled = true): OpenApiBuilder
     {
         $this->config['cleanUnusedComponents'] = ['enabled' => $enabled];
 
@@ -91,11 +101,63 @@ class OpenApiBuilder
     }
 
     /**
-     * List og tags to keep even if unused.
+     * List of tags to keep even if unused.
      */
     public function tagWhitelist(array $whitelist): OpenApiBuilder
     {
         $this->config['augmentTags'] = ['whitelist' => $whitelist];
+
+        return $this;
+    }
+
+    /**
+     * Enable/disable generating tag default descriptions.
+     */
+    public function tagDescriptions(bool $enabled = true): OpenApiBuilder
+    {
+        $this->config['augmentTags'] = ['withDescription' => $enabled];
+
+        return $this;
+    }
+
+    /**
+     * Enable/disable merging of multiple `OA\Components` elements.
+     *
+     * By default, only a single `OA\Components` element is allowed.
+     */
+    public function mergeComponents(bool $enabled = true): OpenApiBuilder
+    {
+        $this->config['mergeIntoOpenApi'] = ['mergeComponents' => $enabled];
+
+        return $this;
+    }
+
+    /**
+     * Specifies the name of the extension variable where backed enum names will be stored.
+     */
+    public function extensionEnumNames(?string $name): OpenApiBuilder
+    {
+        $this->config['expandEnums'] = ['enumNames' => $name];
+
+        return $this;
+    }
+
+    /**
+     * Enable/disable augmenting operation parameters.
+     */
+    public function augmentOperationParameters(bool $enabled = true): OpenApiBuilder
+    {
+        $this->config['augmentParameters'] = ['augmentOperationParameters' => $enabled];
+
+        return $this;
+    }
+
+    /**
+     * Enable/disable ignoring 3rd party attributes.
+     */
+    public function ignoreOtherAttributes(bool $enabled = true): OpenApiBuilder
+    {
+        $this->config['generator'] = ['ignoreOtherAttributes' => $enabled];
 
         return $this;
     }


### PR DESCRIPTION
Also adds support for all missing `Generator` and processor config options.

**BC Breaks:**
* `OpenApiBuilder::clearUnused()` was renamed to `OpenApiBuilder::clearUnusedComponents()`

Fixes #30, fixes #36