### PR TITLE
Fix PHP 8.5 deprecation warning

### DIFF
--- a/src/Processors/MergeControllerDefaults.php
+++ b/src/Processors/MergeControllerDefaults.php
@@ -106,7 +106,7 @@ class MergeControllerDefaults
         $annotations = is_array($annotations) ? $annotations : [$annotations];
 
         foreach ($annotations as $annotation) {
-            $analysis->annotations->detach($annotation);
+            $analysis->annotations->offsetUnset($annotation);
         }
     }
 }

--- a/tests/Fixtures/Middleware/BarMiddleware.php
+++ b/tests/Fixtures/Middleware/BarMiddleware.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Radebatz\OpenApi\Extras\Tests\Fixtures\Middleware;
 

--- a/tests/Fixtures/Middleware/FooMiddleware.php
+++ b/tests/Fixtures/Middleware/FooMiddleware.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Radebatz\OpenApi\Extras\Tests\Fixtures\Middleware;
 


### PR DESCRIPTION
## Summary
- Replace deprecated `SplObjectStorage::detach()` with `offsetUnset()` in `MergeControllerDefaults` processor
- Eliminates repeated deprecation warnings when running on PHP 8.5+

## Test plan
- [x] Full test suite passes with no deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)