### PR TITLE
Update Middleware README section to reflect current usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,26 +188,25 @@ UserResource:
 
 ### `Middleware`
 
-The `Middleware` annotation is currently not used but will be used by a future version
-of the [openapi-router](https://github.com/DerManoMann/openapi-router) project.
+`Middleware` annotations allow to attach a list of middleware names either individually or across all operations (via the `Controller` annotation).
+Controller-level middlewares are merged onto all operations in the class; operation-level middlewares are additive.
 
-`Middleware` annotations allow to share a list of middleware names either individually or across all operations (via the `Controller` annotation).
+This is used by the [openapi-router](https://github.com/DerManoMann/openapi-router) project to configure routing middleware from OpenAPI specs.
 
 ```php
 <?php declare(strict_types=1);
 
-namespace Radebatz\OpenApi\Extras\Tests\Fixtures\Controllers\Attributes;
-
 use OpenApi\Attributes as OAT;
 use Radebatz\OpenApi\Extras\Attributes as OAX;
 
-#[OAX\Controller()]
-#[OAX\Middleware([MyFooMiddleware::class])]
+#[OAX\Controller(
+    middlewares: [new OAX\Middleware([FooMiddleware::class])]
+)]
 class MiddlewareController
 {
     #[OAT\Get(path: '/mw', operationId: 'mw')]
     #[OAT\Response(response: 200, description: 'All good')]
-    #[OAX\Middleware(['BarMiddleware'])]
+    #[OAX\Middleware([BarMiddleware::class])]
     public function mw()
     {
         return 'mw';


### PR DESCRIPTION
## Summary
- Remove outdated "not yet used / future version" caveat from the Middleware section
- Document the merge behavior (controller-level propagates to all operations, operation-level is additive)
- Update the example to use the current `Controller(middlewares: [...])` attribute syntax

## Test plan
- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)