### PR TITLE
Add tags support to Controller annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ $generator = (new OpenApiBuilder())
 
 The controller annotation may be used to:
 * add an optional url prefix to all operations in the class
+* add one or more `Tag`s to all operations in the class
 * share one or more `Response`s across all operations
 * share one or more `Header`'s across all operations
 * share one or more `Middleware`'s across all operations
@@ -140,6 +141,7 @@ class PrefixedController
 Controller annotations are inherited from parent classes. This allows defining shared configuration on a base controller:
 
 * **Prefixes** concatenate: parent `/api/v2` + child `/users` = `/api/v2/users`
+* **Tags** merge (deduplicated)
 * **Responses** merge by response code (child overrides parent for same code)
 * **Headers** merge by header name (child overrides parent for same name)
 * **Middlewares** merge by exact name (deduplicated)
@@ -152,14 +154,14 @@ Set `inherit: false` on a child controller to opt out of inheritance.
 use OpenApi\Attributes as OAT;
 use Radebatz\OpenApi\Extras\Attributes as OAX;
 
-#[OAX\Controller(prefix: '/api/v2')]
+#[OAX\Controller(prefix: '/api/v2', tags: ['api'])]
 #[OAT\Response(response: 403, description: 'Not allowed')]
 #[OAX\Middleware([AuthMiddleware::class])]
 abstract class BaseController
 {
 }
 
-#[OAX\Controller(prefix: '/users')]
+#[OAX\Controller(prefix: '/users', tags: ['users'])]
 #[OAT\Response(response: 404, description: 'Not found')]
 class UserController extends BaseController
 {
@@ -168,6 +170,7 @@ class UserController extends BaseController
     public function list(): mixed
     {
         // effective path: /api/v2/users/list
+        // effective tags: ['api', 'users']
         // effective responses: 200, 403 (from parent), 404 (from child)
         return 'list';
     }

--- a/docs/adr/001-controller-inheritance.md
+++ b/docs/adr/001-controller-inheritance.md
@@ -18,6 +18,10 @@ Support class hierarchy inheritance for `Controller` annotations with the follow
 
 Concatenate from most-distant ancestor to child: parent `/api/v2` + child `/user` = `/api/v2/user`. A child with no prefix inherits the parent prefix unchanged.
 
+### Tags
+
+Merge and deduplicate. Tags from the full controller chain are applied to all operations in the class.
+
 ### Responses
 
 Merge by response code. Child response with same code overrides parent's.

--- a/src/Annotations/Controller.php
+++ b/src/Annotations/Controller.php
@@ -31,6 +31,13 @@ class Controller extends OA\Attachable
     public ?array $headers = null;
 
     /**
+     * Tags to apply to all operations in this controller.
+     *
+     * @var string[]|null
+     */
+    public ?array $tags = null;
+
+    /**
      * Whether to inherit controller settings from parent classes.
      */
     public bool $inherit = true;

--- a/src/Attributes/Controller.php
+++ b/src/Attributes/Controller.php
@@ -16,7 +16,7 @@ class Controller extends \Radebatz\OpenApi\Extras\Annotations\Controller
      * @param string[]|null            $tags
      * @param OAT\Header[]|null        $headers
      * @param OAT\Response[]|null      $responses
-     * @param Middleware[]|null         $middlewares
+     * @param Middleware[]|null        $middlewares
      * @param array<string,mixed>|null $x
      * @param OAT\Attachable[]|null    $attachables
      */

--- a/src/Attributes/Controller.php
+++ b/src/Attributes/Controller.php
@@ -13,14 +13,16 @@ use OpenApi\Generator;
 class Controller extends \Radebatz\OpenApi\Extras\Annotations\Controller
 {
     /**
-     * @param OAT\Header[]             $headers
+     * @param string[]|null            $tags
+     * @param OAT\Header[]|null        $headers
      * @param OAT\Response[]|null      $responses
-     * @param Middleware[]|null        $middlewares
+     * @param Middleware[]|null         $middlewares
      * @param array<string,mixed>|null $x
      * @param OAT\Attachable[]|null    $attachables
      */
     public function __construct(
         ?string $prefix = null,
+        ?array $tags = null,
         ?array $headers = null,
         ?array $responses = null,
         ?array $middlewares = null,
@@ -31,6 +33,7 @@ class Controller extends \Radebatz\OpenApi\Extras\Annotations\Controller
     ) {
         parent::__construct([
             'prefix' => $prefix ?? Generator::UNDEFINED,
+            'tags' => $tags,
             'inherit' => $inherit,
             'x' => $x ?? Generator::UNDEFINED,
             'value' => $this->combine($headers, $responses, $middlewares, $attachables),

--- a/src/Processors/MergeControllerDefaults.php
+++ b/src/Processors/MergeControllerDefaults.php
@@ -174,15 +174,8 @@ class MergeControllerDefaults
             return;
         }
 
-        if (Generator::isDefault($operation->tags)) {
-            $operation->tags = [];
-        }
-
-        foreach ($mergedTags as $tag) {
-            if (!in_array($tag, $operation->tags, true)) {
-                $operation->tags[] = $tag;
-            }
-        }
+        $operationTags = Generator::isDefault($operation->tags) ? [] : $operation->tags;
+        $operation->tags = array_values(array_unique([...$mergedTags, ...$operationTags]));
     }
 
     /**

--- a/src/Processors/MergeControllerDefaults.php
+++ b/src/Processors/MergeControllerDefaults.php
@@ -100,6 +100,7 @@ class MergeControllerDefaults
     protected function applyChain(OA\Operation $operation, array $chain): void
     {
         $mergedPrefix = '';
+        $mergedTags = [];
         $mergedResponses = [];
         $mergedHeaders = [];
         $mergedMiddlewareNames = [];
@@ -107,6 +108,12 @@ class MergeControllerDefaults
         foreach ($chain as $controller) {
             if ($controller->prefix && !Generator::isDefault($controller->prefix)) {
                 $mergedPrefix .= '/' . trim($controller->prefix, '/');
+            }
+
+            if ($controller->tags) {
+                foreach ($controller->tags as $tag) {
+                    $mergedTags[$tag] = $tag;
+                }
             }
 
             if ($controller->responses) {
@@ -144,6 +151,7 @@ class MergeControllerDefaults
         }
 
         $this->applyPrefix($operation, $mergedPrefix);
+        $this->applyTags($operation, $mergedTags);
         $this->applyResponses($operation, $mergedResponses);
         $this->applyHeaders($operation, $mergedHeaders);
         $this->applyMiddlewares($operation, $mergedMiddlewareNames);
@@ -154,6 +162,26 @@ class MergeControllerDefaults
         if ($mergedPrefix !== '') {
             $path = $mergedPrefix . '/' . ltrim($operation->path, '/');
             $operation->path = str_replace('//', '/', $path);
+        }
+    }
+
+    /**
+     * @param array<string, string> $mergedTags
+     */
+    protected function applyTags(OA\Operation $operation, array $mergedTags): void
+    {
+        if ($mergedTags === []) {
+            return;
+        }
+
+        if (Generator::isDefault($operation->tags)) {
+            $operation->tags = [];
+        }
+
+        foreach ($mergedTags as $tag) {
+            if (!in_array($tag, $operation->tags, true)) {
+                $operation->tags[] = $tag;
+            }
         }
     }
 

--- a/tests/Fixtures/Controllers/Annotations/AbstractBaseController.php
+++ b/tests/Fixtures/Controllers/Annotations/AbstractBaseController.php
@@ -9,6 +9,7 @@ use Radebatz\OpenApi\Extras\Tests\Fixtures\Middleware as Middleware;
 /**
  * @OAX\Controller(
  *     prefix="/api/v2",
+ *     tags={"api"},
  *     @OA\Response(response="403", description="Not allowed"),
  *     @OA\Header(header="X-Request-Id", description="Request ID", @OA\Schema(type="string")),
  *     @OAX\Middleware(names={Middleware\FooMiddleware::class, "auth:admin"})

--- a/tests/Fixtures/Controllers/Annotations/InheritedChildController.php
+++ b/tests/Fixtures/Controllers/Annotations/InheritedChildController.php
@@ -9,6 +9,7 @@ use Radebatz\OpenApi\Extras\Tests\Fixtures\Middleware as Middleware;
 /**
  * @OAX\Controller(
  *     prefix="/users",
+ *     tags={"users"},
  *     @OA\Response(response="404", description="Not found"),
  *     @OAX\Middleware(names={Middleware\BarMiddleware::class, "auth:superadmin"})
  * )

--- a/tests/Fixtures/Controllers/Attributes/AbstractBaseController.php
+++ b/tests/Fixtures/Controllers/Attributes/AbstractBaseController.php
@@ -6,7 +6,7 @@ use OpenApi\Attributes as OAT;
 use Radebatz\OpenApi\Extras\Attributes as OAX;
 use Radebatz\OpenApi\Extras\Tests\Fixtures\Middleware\FooMiddleware;
 
-#[OAX\Controller(prefix: '/api/v2')]
+#[OAX\Controller(prefix: '/api/v2', tags: ['api'])]
 #[OAT\Response(response: 403, description: 'Not allowed')]
 #[OAT\Header(
     header: 'X-Request-Id',

--- a/tests/Fixtures/Controllers/Attributes/InheritedChildController.php
+++ b/tests/Fixtures/Controllers/Attributes/InheritedChildController.php
@@ -6,7 +6,7 @@ use OpenApi\Attributes as OAT;
 use Radebatz\OpenApi\Extras\Attributes as OAX;
 use Radebatz\OpenApi\Extras\Tests\Fixtures\Middleware\BarMiddleware;
 
-#[OAX\Controller(prefix: '/users')]
+#[OAX\Controller(prefix: '/users', tags: ['users'])]
 #[OAT\Response(response: 404, description: 'Not found')]
 #[OAX\Middleware([BarMiddleware::class, 'auth:superadmin'])]
 class InheritedChildController extends AbstractBaseController

--- a/tests/Fixtures/spec.yaml
+++ b/tests/Fixtures/spec.yaml
@@ -80,6 +80,9 @@ paths:
                 type: string
   /api/v2/users/list:
     get:
+      tags:
+        - api
+        - users
       operationId: inheritedList
       responses:
         '200':
@@ -112,3 +115,10 @@ paths:
         '500':
           description: 'Server error'
 components: {  }
+tags:
+  -
+    name: api
+    description: api
+  -
+    name: users
+    description: users

--- a/tests/Processors/MergeControllerDefaultsTest.php
+++ b/tests/Processors/MergeControllerDefaultsTest.php
@@ -102,6 +102,18 @@ class MergeControllerDefaultsTest extends TestCase
     /**
      * @dataProvider fixturesProvider
      */
+    public function testInheritedTags(Generator $generator, Finder $finder): void
+    {
+        $operation = $this->getOperation($generator, $finder, 'inheritedList');
+
+        $this->assertIsArray($operation->tags);
+        $this->assertContains('api', $operation->tags);
+        $this->assertContains('users', $operation->tags);
+    }
+
+    /**
+     * @dataProvider fixturesProvider
+     */
     public function testNoInherit(Generator $generator, Finder $finder): void
     {
         $operation = $this->getOperation($generator, $finder, 'isolated');


### PR DESCRIPTION
## Summary
- Add `tags` property to `Controller` annotation/attribute
- Tags are applied to all operations in the controller class
- Tags are inherited and deduplicated through the class hierarchy
- Operations that already have a tag won't get it duplicated

## Test plan
- [x] All tests pass (39 tests, phpstan clean)
- [x] Both annotations and attributes variants tested
- [x] Inheritance of tags verified via `testInheritedTags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)