### PR TITLE
Add JsonResponse shorthand annotation and attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,51 @@ class MiddlewareController
 }
 ```
 
+### `JsonResponse`
+
+A shorthand for JSON responses that reference a schema. Reduces nesting by wrapping the ref/type in a `JsonContent` automatically.
+
+If no `description` is provided, it is derived from the referenced schema (fallback order: title > description > schema name > class short name).
+
+```php
+<?php declare(strict_types=1);
+
+use OpenApi\Attributes as OAT;
+use Radebatz\OpenApi\Extras\Attributes as OAX;
+
+#[OAT\Schema(schema: 'TokenPairResource', title: 'Token pair')]
+class TokenPairResource
+{
+    #[OAT\Property(property: 'access_token', type: 'string')]
+    public string $accessToken;
+
+    #[OAT\Property(property: 'refresh_token', type: 'string')]
+    public string $refreshToken;
+}
+
+class AuthController
+{
+    #[OAT\Post(path: '/auth/login', operationId: 'login')]
+    #[OAX\JsonResponse(response: 200, ref: TokenPairResource::class)]
+    #[OAX\JsonResponse(response: 401, description: 'Invalid credentials')]
+    public function login(): mixed
+    {
+        // response 200 description auto-derived as "Token pair" from schema title
+        return '...';
+    }
+}
+```
+
+This is equivalent to the more verbose:
+
+```php
+#[OAT\Response(
+    response: 200,
+    description: 'Token pair',
+    content: new OAT\JsonContent(ref: TokenPairResource::class)
+)]
+```
+
 
 ## License
 

--- a/src/Annotations/JsonResponse.php
+++ b/src/Annotations/JsonResponse.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras\Annotations;
+
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
+
+/**
+ * Shorthand for a JSON response with a schema ref or type.
+ *
+ * @Annotation
+ */
+class JsonResponse extends OA\Response
+{
+    /** @var string|class-string */
+    public $ref = Generator::UNDEFINED;
+
+    /** @var string|class-string|null */
+    public $type = Generator::UNDEFINED;
+
+    public function __construct(array $properties)
+    {
+        $ref = $properties['ref'] ?? Generator::UNDEFINED;
+        $type = $properties['type'] ?? Generator::UNDEFINED;
+
+        $jsonContentProps = [];
+        if (!Generator::isDefault($ref)) {
+            $jsonContentProps['ref'] = $ref;
+        }
+        if (!Generator::isDefault($type)) {
+            $jsonContentProps['type'] = $type;
+        }
+
+        if ($jsonContentProps !== []) {
+            $jsonContent = new OA\JsonContent($jsonContentProps);
+            $properties['value'] = array_merge($properties['value'] ?? [], [$jsonContent]);
+        }
+
+        parent::__construct($properties);
+    }
+}

--- a/src/Annotations/JsonResponse.php
+++ b/src/Annotations/JsonResponse.php
@@ -13,22 +13,24 @@ use OpenApi\Generator;
 class JsonResponse extends OA\Response
 {
     /** @var string|class-string */
-    public $ref = Generator::UNDEFINED;
+    public $source = Generator::UNDEFINED;
 
-    /** @var string|class-string|null */
-    public $type = Generator::UNDEFINED;
+    public static $_blacklist = ['_context', '_unmerged', '_analysis', 'attachables', 'source'];
 
     public function __construct(array $properties)
     {
         $ref = $properties['ref'] ?? Generator::UNDEFINED;
         $type = $properties['type'] ?? Generator::UNDEFINED;
+        unset($properties['ref'], $properties['type']);
 
         $jsonContentProps = [];
         if (!Generator::isDefault($ref)) {
             $jsonContentProps['ref'] = $ref;
+            $properties['source'] = $ref;
         }
         if (!Generator::isDefault($type)) {
             $jsonContentProps['type'] = $type;
+            $properties['source'] = $properties['source'] ?? $type;
         }
 
         if ($jsonContentProps !== []) {

--- a/src/Attributes/JsonResponse.php
+++ b/src/Attributes/JsonResponse.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras\Attributes;
+
+use OpenApi\Attributes as OAT;
+use OpenApi\Generator;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+class JsonResponse extends \Radebatz\OpenApi\Extras\Annotations\JsonResponse
+{
+    /**
+     * @param string|class-string      $ref
+     * @param string|class-string|null $type
+     * @param OAT\Header[]|null        $headers
+     * @param array<string,mixed>|null $x
+     * @param OAT\Attachable[]|null    $attachables
+     */
+    public function __construct(
+        int|string $response = Generator::UNDEFINED,
+        string|object $ref = Generator::UNDEFINED,
+        string|null $type = null,
+        ?string $description = null,
+        ?array $headers = null,
+        ?array $x = null,
+        ?array $attachables = null,
+    ) {
+        parent::__construct([
+            'ref' => $ref,
+            'type' => $type ?? Generator::UNDEFINED,
+            'response' => $response,
+            'description' => $description ?? Generator::UNDEFINED,
+            'x' => $x ?? Generator::UNDEFINED,
+            'value' => $this->combine($headers, $attachables),
+        ]);
+    }
+}

--- a/src/OpenApiBuilder.php
+++ b/src/OpenApiBuilder.php
@@ -7,6 +7,7 @@ use OpenApi\Generator;
 use OpenApi\Processors\BuildPaths;
 use OpenApi\Processors\ExpandEnums;
 use Psr\Log\LoggerInterface;
+use Radebatz\OpenApi\Extras\Processors\AugmentJsonResponse;
 use Radebatz\OpenApi\Extras\Processors\Customizers;
 use Radebatz\OpenApi\Extras\Processors\EnumDescription;
 use Radebatz\OpenApi\Extras\Processors\MergeControllerDefaults;
@@ -191,7 +192,8 @@ class OpenApiBuilder
         }
 
         $generator->getProcessorPipeline()
-            ->insert(new MergeControllerDefaults(), BuildPaths::class);
+            ->insert(new MergeControllerDefaults(), BuildPaths::class)
+            ->insert(new AugmentJsonResponse(), BuildPaths::class);
 
         if ($this->customizers) {
             $generator->getProcessorPipeline()

--- a/src/Processors/AugmentJsonResponse.php
+++ b/src/Processors/AugmentJsonResponse.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras\Processors;
+
+use OpenApi\Analysis;
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
+use Radebatz\OpenApi\Extras\Annotations\JsonResponse;
+
+class AugmentJsonResponse
+{
+    public function __invoke(Analysis $analysis): void
+    {
+        /** @var JsonResponse[] $responses */
+        $responses = $analysis->getAnnotationsOfType(JsonResponse::class);
+
+        foreach ($responses as $response) {
+            if (!Generator::isDefault($response->description)) {
+                continue;
+            }
+
+            $source = Generator::isDefault($response->ref) ? $response->type : $response->ref;
+            if ($source && !Generator::isDefault($source)) {
+                $response->description = $this->resolveDescription($source, $analysis);
+            }
+        }
+    }
+
+    protected function resolveDescription(string $source, Analysis $analysis): string
+    {
+        $schema = $analysis->getAnnotationForSource($source, OA\Schema::class);
+
+        if ($schema instanceof OA\Schema) {
+            if (!Generator::isDefault($schema->title)) {
+                return $schema->title;
+            }
+            if (!Generator::isDefault($schema->description)) {
+                return $schema->description;
+            }
+            if (!Generator::isDefault($schema->schema)) {
+                return $schema->schema;
+            }
+        }
+
+        // Fallback to short class name
+        $pos = strrpos($source, '\\');
+
+        return $pos !== false ? substr($source, $pos + 1) : $source;
+    }
+}

--- a/src/Processors/AugmentJsonResponse.php
+++ b/src/Processors/AugmentJsonResponse.php
@@ -11,7 +11,6 @@ class AugmentJsonResponse
 {
     public function __invoke(Analysis $analysis): void
     {
-        /** @var JsonResponse[] $responses */
         $responses = $analysis->getAnnotationsOfType(JsonResponse::class);
 
         foreach ($responses as $response) {

--- a/src/Processors/AugmentJsonResponse.php
+++ b/src/Processors/AugmentJsonResponse.php
@@ -19,9 +19,8 @@ class AugmentJsonResponse
                 continue;
             }
 
-            $source = Generator::isDefault($response->ref) ? $response->type : $response->ref;
-            if ($source && !Generator::isDefault($source)) {
-                $response->description = $this->resolveDescription($source, $analysis);
+            if (!Generator::isDefault($response->source)) {
+                $response->description = $this->resolveDescription($response->source, $analysis);
             }
         }
     }

--- a/src/Processors/EnumDescription.php
+++ b/src/Processors/EnumDescription.php
@@ -39,7 +39,6 @@ class EnumDescription
             return;
         }
 
-        /** @var OA\Property[] $properties */
         $properties = $analysis->getAnnotationsOfType(OA\Property::class);
 
         foreach ($properties as $property) {

--- a/src/Processors/MergeControllerDefaults.php
+++ b/src/Processors/MergeControllerDefaults.php
@@ -12,9 +12,7 @@ class MergeControllerDefaults
 {
     public function __invoke(Analysis $analysis)
     {
-        /** @var OAX\Controller[] $controllers */
         $controllers = $analysis->getAnnotationsOfType(OAX\Controller::class);
-        /** @var OA\Operation[] $operations */
         $operations = $analysis->getAnnotationsOfType(OA\Operation::class);
 
         $controllerMap = $this->buildControllerMap($controllers);

--- a/tests/Fixtures/Models/TokenPairResource.php
+++ b/tests/Fixtures/Models/TokenPairResource.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras\Tests\Fixtures\Models;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema(schema: 'TokenPairResource', title: 'Token pair')]
+class TokenPairResource
+{
+    #[OAT\Property(property: 'access_token', type: 'string')]
+    public string $accessToken;
+
+    #[OAT\Property(property: 'refresh_token', type: 'string')]
+    public string $refreshToken;
+}

--- a/tests/JsonResponseTest.php
+++ b/tests/JsonResponseTest.php
@@ -1,0 +1,120 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras\Tests;
+
+use OpenApi\Analysis;
+use OpenApi\Annotations as OA;
+use OpenApi\Context;
+use OpenApi\Generator;
+use PHPUnit\Framework\TestCase;
+use Radebatz\OpenApi\Extras\Annotations\JsonResponse as JsonResponseAnnotation;
+use Radebatz\OpenApi\Extras\Attributes\JsonResponse;
+use Radebatz\OpenApi\Extras\Processors\AugmentJsonResponse;
+use Radebatz\OpenApi\Extras\Tests\Fixtures\Models\TokenPairResource;
+
+class JsonResponseTest extends TestCase
+{
+    public function testAttributeWithRef(): void
+    {
+        $response = new JsonResponse(response: 200, ref: TokenPairResource::class);
+
+        $this->assertEquals(200, $response->response);
+        $this->assertNotEmpty($response->_unmerged);
+        $this->assertInstanceOf(OA\JsonContent::class, $response->_unmerged[0]);
+    }
+
+    public function testAttributeExplicitDescription(): void
+    {
+        $response = new JsonResponse(response: 200, ref: TokenPairResource::class, description: 'Custom desc');
+
+        $this->assertEquals('Custom desc', $response->description);
+    }
+
+    public function testAttributeNoRef(): void
+    {
+        $response = new JsonResponse(response: 204);
+
+        $this->assertEquals(Generator::UNDEFINED, $response->description);
+    }
+
+    public function testAnnotationWithRef(): void
+    {
+        $response = new JsonResponseAnnotation([
+            'response' => 200,
+            'ref' => TokenPairResource::class,
+        ]);
+
+        $this->assertEquals(200, $response->response);
+        $this->assertNotEmpty($response->_unmerged);
+        $this->assertInstanceOf(OA\JsonContent::class, $response->_unmerged[0]);
+    }
+
+    public function testProcessorResolvesDescriptionFromTitle(): void
+    {
+        $analysis = $this->createAnalysisWithSchema(TokenPairResource::class, 'Token pair', Generator::UNDEFINED);
+
+        $response = new JsonResponse(response: 200, ref: TokenPairResource::class);
+        $analysis->addAnnotation($response, new Context([]));
+
+        (new AugmentJsonResponse())($analysis);
+
+        $this->assertEquals('Token pair', $response->description);
+    }
+
+    public function testProcessorResolvesDescriptionFromSchemaDescription(): void
+    {
+        $analysis = $this->createAnalysisWithSchema(TokenPairResource::class, Generator::UNDEFINED, 'A token pair response');
+
+        $response = new JsonResponse(response: 200, ref: TokenPairResource::class);
+        $analysis->addAnnotation($response, new Context([]));
+
+        (new AugmentJsonResponse())($analysis);
+
+        $this->assertEquals('A token pair response', $response->description);
+    }
+
+    public function testProcessorFallsBackToClassName(): void
+    {
+        $analysis = new Analysis([], new Context([]));
+
+        $response = new JsonResponse(response: 200, ref: 'App\\Models\\SomeUnknownClass');
+        $analysis->addAnnotation($response, new Context([]));
+
+        (new AugmentJsonResponse())($analysis);
+
+        $this->assertEquals('SomeUnknownClass', $response->description);
+    }
+
+    public function testProcessorSkipsExplicitDescription(): void
+    {
+        $analysis = $this->createAnalysisWithSchema(TokenPairResource::class, 'Token pair', Generator::UNDEFINED);
+
+        $response = new JsonResponse(response: 200, ref: TokenPairResource::class, description: 'My desc');
+        $analysis->addAnnotation($response, new Context([]));
+
+        (new AugmentJsonResponse())($analysis);
+
+        $this->assertEquals('My desc', $response->description);
+    }
+
+    protected function createAnalysisWithSchema(string $class, string $title, string $description): Analysis
+    {
+        $shortName = substr($class, strrpos($class, '\\') + 1);
+        $namespace = substr($class, 0, strrpos($class, '\\'));
+
+        $context = new Context(['namespace' => $namespace, 'class' => $shortName]);
+        $schema = new OA\Schema([
+            'schema' => $shortName,
+            'title' => $title,
+            'description' => $description,
+            '_context' => $context,
+        ]);
+        $context->annotations = [$schema];
+
+        $analysis = new Analysis([], new Context([]));
+        $analysis->addClassDefinition(['class' => $shortName, 'context' => $context]);
+        $analysis->addAnnotation($schema, $context);
+
+        return $analysis;
+    }
+}


### PR DESCRIPTION
## Summary
- New `JsonResponse` annotation/attribute that wraps a schema `ref` or `type` in a `JsonContent` response
- New `AugmentJsonResponse` processor that auto-derives response description from the referenced schema (fallback order: title > description > schema name > class short name)
- Explicit `description` parameter takes precedence over auto-derivation
- Leverages swagger-php's `MergeJsonContent` and `AugmentRefs` for ref resolution

### Usage
```php
// Before
#[OAT\Response(response: 200, description: 'Token pair', content: new OAT\JsonContent(ref: TokenPairResource::class))]

// After
#[OAX\JsonResponse(response: 200, ref: TokenPairResource::class)]
```

## Test plan
- [x] 47 tests pass
- [x] phpstan clean
- [x] rector clean
- [x] php-cs-fixer clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)