### PR TITLE
Remove redundant @var annotations and add missing return types

### DIFF
--- a/src/Processors/Customizers.php
+++ b/src/Processors/Customizers.php
@@ -38,7 +38,7 @@ class Customizers
         return $this->mappings;
     }
 
-    public function __invoke(Analysis $analysis)
+    public function __invoke(Analysis $analysis): void
     {
         foreach ($this->mappings as $classname => $callables) {
             $annotations = $analysis->getAnnotationsOfType($classname);

--- a/src/Processors/EnumDescription.php
+++ b/src/Processors/EnumDescription.php
@@ -33,13 +33,12 @@ class EnumDescription
         return $this;
     }
 
-    public function __invoke(Analysis $analysis)
+    public function __invoke(Analysis $analysis): void
     {
         if (!class_exists('\\ReflectionEnum')) {
             return;
         }
 
-        /** @var OA\Property[] $properties */
         $properties = $analysis->getAnnotationsOfType(OA\Property::class);
 
         foreach ($properties as $property) {

--- a/src/Processors/MergeControllerDefaults.php
+++ b/src/Processors/MergeControllerDefaults.php
@@ -10,11 +10,9 @@ use Radebatz\OpenApi\Extras\Annotations as OAX;
 
 class MergeControllerDefaults
 {
-    public function __invoke(Analysis $analysis)
+    public function __invoke(Analysis $analysis): void
     {
-        /** @var OAX\Controller[] $controllers */
         $controllers = $analysis->getAnnotationsOfType(OAX\Controller::class);
-        /** @var OA\Operation[] $operations */
         $operations = $analysis->getAnnotationsOfType(OA\Operation::class);
 
         $controllerMap = $this->buildControllerMap($controllers);

--- a/tests/OpenApiBuilderTest.php
+++ b/tests/OpenApiBuilderTest.php
@@ -22,7 +22,7 @@ class OpenApiBuilderTest extends TestCase
         return $rp->getValue($pipeline);
     }
 
-    protected function getPipe(array $pipes, string $pipeClass)
+    protected function getPipe(array $pipes, string $pipeClass): ?object
     {
         foreach ($pipes as $pipe) {
             if ($pipe instanceof $pipeClass) {

--- a/tests/Processors/MergeControllerDefaultsTest.php
+++ b/tests/Processors/MergeControllerDefaultsTest.php
@@ -138,7 +138,6 @@ class MergeControllerDefaultsTest extends TestCase
                 return $analysis;
             });
 
-        /** @var OA\Operation[] $operations */
         $operations = $analysis->getAnnotationsOfType(OA\Operation::class);
         foreach ($operations as $operation) {
             if ($operation->operationId === $operationId) {


### PR DESCRIPTION
## Summary
- Remove inline `@var` on `getAnnotationsOfType` calls — the method's generic `@template T` return type handles inference
- Add `void` return type to all processor `__invoke` methods
- Add return type to test helper `getPipe()`

## Test plan
- [x] phpstan clean
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)