### PR TITLE
Fix `JsonResponse` attribute type hierarchy

### DIFF
--- a/src/Annotations/JsonResponse.php
+++ b/src/Annotations/JsonResponse.php
@@ -21,7 +21,7 @@ class JsonResponse extends OA\Response
         $type = $properties['type'] ?? Generator::UNDEFINED;
         unset($properties['ref'], $properties['type']);
 
-        $resolved = $this->resolveSource($ref, !Generator::isDefault($type) ? $type : null);
+        $resolved = $this->resolveSource($ref, Generator::isDefault($type) ? null : $type);
 
         if ($resolved['ref'] !== null || $resolved['type'] !== null) {
             $jsonContent = new OA\JsonContent(array_filter($resolved));

--- a/src/Annotations/JsonResponse.php
+++ b/src/Annotations/JsonResponse.php
@@ -4,6 +4,7 @@ namespace Radebatz\OpenApi\Extras\Annotations;
 
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
+use Radebatz\OpenApi\Extras\JsonResponseTrait;
 
 /**
  * Shorthand for a JSON response with a schema ref or type.
@@ -12,10 +13,7 @@ use OpenApi\Generator;
  */
 class JsonResponse extends OA\Response
 {
-    /** @var string|class-string */
-    public $source = Generator::UNDEFINED;
-
-    public static $_blacklist = ['_context', '_unmerged', '_analysis', 'attachables', 'source'];
+    use JsonResponseTrait;
 
     public function __construct(array $properties)
     {
@@ -23,18 +21,10 @@ class JsonResponse extends OA\Response
         $type = $properties['type'] ?? Generator::UNDEFINED;
         unset($properties['ref'], $properties['type']);
 
-        $jsonContentProps = [];
-        if (!Generator::isDefault($ref)) {
-            $jsonContentProps['ref'] = $ref;
-            $properties['source'] = $ref;
-        }
-        if (!Generator::isDefault($type)) {
-            $jsonContentProps['type'] = $type;
-            $properties['source'] = $properties['source'] ?? $type;
-        }
+        $resolved = $this->resolveSource($ref, !Generator::isDefault($type) ? $type : null);
 
-        if ($jsonContentProps !== []) {
-            $jsonContent = new OA\JsonContent($jsonContentProps);
+        if ($resolved['ref'] !== null || $resolved['type'] !== null) {
+            $jsonContent = new OA\JsonContent(array_filter($resolved));
             $properties['value'] = array_merge($properties['value'] ?? [], [$jsonContent]);
         }
 

--- a/src/Attributes/JsonResponse.php
+++ b/src/Attributes/JsonResponse.php
@@ -4,10 +4,13 @@ namespace Radebatz\OpenApi\Extras\Attributes;
 
 use OpenApi\Attributes as OAT;
 use OpenApi\Generator;
+use Radebatz\OpenApi\Extras\JsonResponseTrait;
 
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
-class JsonResponse extends \Radebatz\OpenApi\Extras\Annotations\JsonResponse
+class JsonResponse extends OAT\Response
 {
+    use JsonResponseTrait;
+
     /**
      * @param string|class-string      $ref
      * @param string|class-string|null $type
@@ -24,13 +27,19 @@ class JsonResponse extends \Radebatz\OpenApi\Extras\Annotations\JsonResponse
         ?array $x = null,
         ?array $attachables = null,
     ) {
-        parent::__construct([
-            'ref' => $ref,
-            'type' => $type ?? Generator::UNDEFINED,
-            'response' => $response,
-            'description' => $description ?? Generator::UNDEFINED,
-            'x' => $x ?? Generator::UNDEFINED,
-            'value' => $this->combine($headers, $attachables),
-        ]);
+        $resolved = $this->resolveSource($ref, $type);
+
+        $jsonContent = ($resolved['ref'] !== null || $resolved['type'] !== null)
+            ? new OAT\JsonContent(ref: $resolved['ref'], type: $resolved['type'])
+            : null;
+
+        parent::__construct(
+            response: $response !== Generator::UNDEFINED ? $response : null,
+            description: $description ?? Generator::UNDEFINED,
+            headers: $headers,
+            content: $jsonContent,
+            x: $x,
+            attachables: $attachables,
+        );
     }
 }

--- a/src/JsonResponseTrait.php
+++ b/src/JsonResponseTrait.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras;
+
+use OpenApi\Generator;
+
+trait JsonResponseTrait
+{
+    /** @var string|class-string */
+    public $source = Generator::UNDEFINED;
+
+    public static $_blacklist = ['_context', '_unmerged', '_analysis', 'attachables', 'source'];
+
+    /**
+     * @return array{ref: string|class-string|null, type: string|class-string|null}
+     */
+    protected function resolveSource(string|object $ref, ?string $type): array
+    {
+        $resolvedRef = null;
+        $resolvedType = null;
+
+        if (!Generator::isDefault($ref)) {
+            $resolvedRef = $ref;
+            $this->source = $ref;
+        }
+        if ($type !== null) {
+            $resolvedType = $type;
+            $this->source = $this->source !== Generator::UNDEFINED ? $this->source : $type;
+        }
+
+        return ['ref' => $resolvedRef, 'type' => $resolvedType];
+    }
+}

--- a/src/Processors/AugmentJsonResponse.php
+++ b/src/Processors/AugmentJsonResponse.php
@@ -5,13 +5,14 @@ namespace Radebatz\OpenApi\Extras\Processors;
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
-use Radebatz\OpenApi\Extras\Annotations\JsonResponse;
+use Radebatz\OpenApi\Extras\Annotations as OAX;
+use Radebatz\OpenApi\Extras\Attributes as OAXT;
 
 class AugmentJsonResponse
 {
     public function __invoke(Analysis $analysis): void
     {
-        $responses = $analysis->getAnnotationsOfType(JsonResponse::class);
+        $responses = $analysis->getAnnotationsOfType([OAX\JsonResponse::class, OAXT\JsonResponse::class]);
 
         foreach ($responses as $response) {
             if (!Generator::isDefault($response->description)) {


### PR DESCRIPTION
## Summary
- `Attributes\JsonResponse` now extends `OAT\Response` directly instead of `Annotations\JsonResponse`, fixing type mismatch warnings when used in Controller's `responses` parameter (which expects `OAT\Response[]`)
- Extracted shared `source` property and resolution logic into `JsonResponseTrait`, used by both annotation and attribute variants
- Updated `AugmentJsonResponse` processor to find both class hierarchies using `OAX`/`OAXT` aliases

## Test plan
- [x] All 47 existing tests pass
- [ ] Verify no IDE/PHPStan warnings when using `JsonResponse` in Controller's `responses` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)