### PR TITLE
Add ProvidesCustomizersInterface for middleware-driven OpenAPI customizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,59 @@ class MiddlewareController
 }
 ```
 
+#### `ProvidesCustomizersInterface`
+
+Middleware subclasses can implement `ProvidesCustomizersInterface` to automatically apply OpenAPI modifications to operations that carry them. This eliminates duplication — for example, a `jwt-auth` middleware can auto-inject the `security` scheme without every operation declaring it manually.
+
+```php
+<?php declare(strict_types=1);
+
+use OpenApi\Annotations as OA;
+use Radebatz\OpenApi\Extras\Attributes\Middleware;
+use Radebatz\OpenApi\Extras\ProvidesCustomizersInterface;
+
+#[\Attribute(\Attribute::TARGET_ALL | \Attribute::IS_REPEATABLE)]
+class SecureMiddleware extends Middleware implements ProvidesCustomizersInterface
+{
+    public function __construct()
+    {
+        parent::__construct(names: ['jwt-auth']);
+    }
+
+    public static function customizers(): array
+    {
+        return [
+            OA\Operation::class => [
+                fn (OA\Operation $op) => $op->security = [['bearerAuth' => []]],
+            ],
+        ];
+    }
+}
+```
+
+Then use it on a controller — all operations inherit both the middleware name and the security effect:
+
+```php
+<?php declare(strict_types=1);
+
+use OpenApi\Attributes as OAT;
+use Radebatz\OpenApi\Extras\Attributes as OAX;
+
+#[OAX\Controller(middlewares: [new SecureMiddleware()])]
+class UserController
+{
+    #[OAT\Get(path: '/users', operationId: 'listUsers')]
+    #[OAT\Response(response: 200, description: 'All good')]
+    public function list(): mixed
+    {
+        // security: [['bearerAuth' => []]] is applied automatically
+        return 'list';
+    }
+}
+```
+
+The `customizers()` method returns the same mapping format as the `Customizers` processor (`annotation class => callable[]`), but these are scoped — they only apply to operations carrying the middleware, not globally.
+
 ### `JsonResponse`
 
 A shorthand for JSON responses that reference a schema. Reduces nesting by wrapping the ref/type in a `JsonContent` automatically.

--- a/docs/adr/002-processor-pipeline-ordering.md
+++ b/docs/adr/002-processor-pipeline-ordering.md
@@ -24,6 +24,15 @@ This processor generates human-readable descriptions from PHP enum cases. It mus
 
 - `ExpandEnums` replaces enum class references with their scalar values. After it runs, the link back to the `ReflectionEnum` (needed to enumerate case names) is lost.
 
+### `MiddlewareCustomizers` — inserted before `AugmentParameters`
+
+This processor applies scoped customizers from middleware classes implementing `ProvidesCustomizersInterface`. It runs **after** `BuildPaths` because:
+
+- Operations must be fully assembled with their merged middleware attachables (done by `MergeControllerDefaults` before `BuildPaths`).
+- It needs to see the final operation structure to apply mutations like `security`.
+
+It runs **before** `AugmentParameters` so that any parameters or references added by middleware customizers are still processed by the standard augmentation pipeline.
+
 ### `Customizers` — appended at the end
 
 This processor invokes user-defined callbacks on annotation instances. It runs **last** because:

--- a/docs/adr/003-middleware-provides-customizers.md
+++ b/docs/adr/003-middleware-provides-customizers.md
@@ -1,0 +1,85 @@
+# ADR-003: Middleware Provides Customizers
+
+## Status
+
+Accepted
+
+## Context
+
+Controllers often declare middleware that implies OpenAPI metadata. For example, a `jwt-auth` middleware means the operation requires bearer authentication — yet users must manually add `security: [['bearerAuth' => []]]` to every operation. This duplication is error-prone and violates DRY.
+
+The library already has a `Customizers` processor for global callbacks, but those apply to all instances of an annotation type. What's needed is *scoped* customizers — OpenAPI modifications that only apply to operations carrying a specific middleware.
+
+## Decision
+
+### `ProvidesCustomizersInterface`
+
+A new interface that any `Middleware` subclass can implement:
+
+```php
+interface ProvidesCustomizersInterface
+{
+    /** @return array<class-string<OA\AbstractAnnotation>, callable[]> */
+    public static function customizers(): array;
+}
+```
+
+The return format matches the existing `Customizers` processor's mapping shape — annotation class to list of callables.
+
+### Custom middleware attributes
+
+Users extend `OAX\Middleware` to create self-contained middleware annotations that carry both the middleware name(s) and the OpenAPI effect:
+
+```php
+#[\Attribute(\Attribute::TARGET_ALL | \Attribute::IS_REPEATABLE)]
+class SecureMiddleware extends Middleware implements ProvidesCustomizersInterface
+{
+    public function __construct()
+    {
+        parent::__construct(names: ['jwt-auth']);
+    }
+
+    public static function customizers(): array
+    {
+        return [
+            OA\Operation::class => [
+                fn (OA\Operation $op) => $op->security = [['bearerAuth' => []]],
+            ],
+        ];
+    }
+}
+```
+
+Usage becomes `#[SecureMiddleware]` — no redundant security annotation needed.
+
+### Preserving original instances through merge
+
+`MergeControllerDefaults` already collapses all middleware into a single `Middleware` instance with merged names. To preserve typed instances for later processing, the original middleware objects are stored as nested attachables on the merged `Middleware`:
+
+```php
+$middleware = new OAX\Middleware([
+    'names' => array_values($mergedMiddlewareNames),
+    'value' => array_values($mergedMiddlewareInstances),
+]);
+```
+
+This required adding `$_nested = [OA\Attachable::class => ['attachables']]` to the `Middleware` annotation.
+
+### `MiddlewareCustomizers` processor
+
+A single-pass processor that runs after `BuildPaths` (operations are fully resolved). It:
+
+1. Iterates all operations
+2. Finds the merged `Middleware` attachable
+3. Checks its nested attachables for `ProvidesCustomizersInterface` implementors
+4. Applies their customizers to the operation
+
+Customizers are scoped — they only affect operations that carry the middleware, unlike global `Customizers` which apply to all instances.
+
+## Consequences
+
+- Middleware subclasses are the primary extension point. No registration step needed — implement the interface and use the attribute.
+- The interface is not coupled to `Middleware` specifically. Any attachable could implement it in the future if a similar pattern emerges.
+- String-based middleware names (e.g., `'jwt-auth'`) cannot provide customizers directly — only class-based middleware can. Users needing effects for string-only middleware should create a wrapping attribute class.
+- The `Middleware` annotation now supports nested attachables, which is a backward-compatible addition.
+- Pipeline ordering: `MiddlewareCustomizers` runs after `BuildPaths` but before `AugmentParameters`, so it sees fully assembled operations but can still influence parameter augmentation.

--- a/src/Annotations/Middleware.php
+++ b/src/Annotations/Middleware.php
@@ -21,6 +21,13 @@ class Middleware extends OA\Attachable
     /**
      * @inheritdoc
      */
+    public static $_nested = [
+        OA\Attachable::class => ['attachables'],
+    ];
+
+    /**
+     * @inheritdoc
+     */
     public static $_required = ['names'];
 
     /**

--- a/src/Attributes/Controller.php
+++ b/src/Attributes/Controller.php
@@ -8,9 +8,10 @@ namespace Radebatz\OpenApi\Extras\Attributes;
 
 use OpenApi\Attributes as OAT;
 use OpenApi\Generator;
+use Radebatz\OpenApi\Extras\Annotations as OAX;
 
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class Controller extends \Radebatz\OpenApi\Extras\Annotations\Controller
+class Controller extends OAX\Controller
 {
     /**
      * @param string[]|null            $tags

--- a/src/Attributes/Middleware.php
+++ b/src/Attributes/Middleware.php
@@ -3,9 +3,10 @@
 namespace Radebatz\OpenApi\Extras\Attributes;
 
 use OpenApi\Generator;
+use Radebatz\OpenApi\Extras\Annotations as OAX;
 
 #[\Attribute(\Attribute::TARGET_ALL | \Attribute::IS_REPEATABLE)]
-class Middleware extends \Radebatz\OpenApi\Extras\Annotations\Middleware
+class Middleware extends OAX\Middleware
 {
     /**
      * @param array<string|class-string>|null $names
@@ -19,7 +20,6 @@ class Middleware extends \Radebatz\OpenApi\Extras\Annotations\Middleware
         parent::__construct([
             'names' => $names ?? Generator::UNDEFINED,
             'x' => $x ?? Generator::UNDEFINED,
-            'attachables' => $attachables ?? Generator::UNDEFINED,
             'value' => $this->combine($attachables),
         ]);
     }

--- a/src/OpenApiBuilder.php
+++ b/src/OpenApiBuilder.php
@@ -4,6 +4,7 @@ namespace Radebatz\OpenApi\Extras;
 
 use OpenApi\Annotations as OA;
 use OpenApi\Generator;
+use OpenApi\Processors\AugmentParameters;
 use OpenApi\Processors\BuildPaths;
 use OpenApi\Processors\ExpandEnums;
 use Psr\Log\LoggerInterface;
@@ -11,6 +12,7 @@ use Radebatz\OpenApi\Extras\Processors\AugmentJsonResponse;
 use Radebatz\OpenApi\Extras\Processors\Customizers;
 use Radebatz\OpenApi\Extras\Processors\EnumDescription;
 use Radebatz\OpenApi\Extras\Processors\MergeControllerDefaults;
+use Radebatz\OpenApi\Extras\Processors\MiddlewareCustomizers;
 
 /**
  * A simple `builder` wrapper around the OpenApi `Generator` class.
@@ -193,7 +195,8 @@ class OpenApiBuilder
 
         $generator->getProcessorPipeline()
             ->insert(new MergeControllerDefaults(), BuildPaths::class)
-            ->insert(new AugmentJsonResponse(), BuildPaths::class);
+            ->insert(new AugmentJsonResponse(), BuildPaths::class)
+            ->insert(new MiddlewareCustomizers(), AugmentParameters::class);
 
         if ($this->customizers) {
             $generator->getProcessorPipeline()

--- a/src/Processors/MergeControllerDefaults.php
+++ b/src/Processors/MergeControllerDefaults.php
@@ -102,6 +102,7 @@ class MergeControllerDefaults
         $mergedResponses = [];
         $mergedHeaders = [];
         $mergedMiddlewareNames = [];
+        $mergedMiddlewareInstances = [];
 
         foreach ($chain as $controller) {
             if ($controller->prefix && !Generator::isDefault($controller->prefix)) {
@@ -129,6 +130,7 @@ class MergeControllerDefaults
             if (!Generator::isDefault($controller->attachables)) {
                 foreach ($controller->attachables as $attachable) {
                     if ($attachable instanceof OAX\Middleware && $attachable->names) {
+                        $mergedMiddlewareInstances[get_class($attachable)] = $attachable;
                         foreach ($attachable->names as $name) {
                             $mergedMiddlewareNames[$name] = $name;
                         }
@@ -141,6 +143,7 @@ class MergeControllerDefaults
         if (!Generator::isDefault($operation->attachables)) {
             foreach ($operation->attachables as $attachable) {
                 if ($attachable instanceof OAX\Middleware && $attachable->names) {
+                    $mergedMiddlewareInstances[get_class($attachable)] = $attachable;
                     foreach ($attachable->names as $name) {
                         $mergedMiddlewareNames[$name] = $name;
                     }
@@ -152,7 +155,7 @@ class MergeControllerDefaults
         $this->applyTags($operation, $mergedTags);
         $this->applyResponses($operation, $mergedResponses);
         $this->applyHeaders($operation, $mergedHeaders);
-        $this->applyMiddlewares($operation, $mergedMiddlewareNames);
+        $this->applyMiddlewares($operation, $mergedMiddlewareNames, $mergedMiddlewareInstances);
     }
 
     protected function applyPrefix(OA\Operation $operation, string $mergedPrefix): void
@@ -203,9 +206,10 @@ class MergeControllerDefaults
     }
 
     /**
-     * @param array<string, string> $mergedMiddlewareNames
+     * @param array<string, string>               $mergedMiddlewareNames
+     * @param array<class-string, OAX\Middleware> $mergedMiddlewareInstances
      */
-    protected function applyMiddlewares(OA\Operation $operation, array $mergedMiddlewareNames): void
+    protected function applyMiddlewares(OA\Operation $operation, array $mergedMiddlewareNames, array $mergedMiddlewareInstances = []): void
     {
         if ($mergedMiddlewareNames === []) {
             return;
@@ -220,7 +224,10 @@ class MergeControllerDefaults
             $operation->attachables = $remaining ?: Generator::UNDEFINED;
         }
 
-        $middleware = new OAX\Middleware(['names' => array_values($mergedMiddlewareNames)]);
+        $middleware = new OAX\Middleware([
+            'names' => array_values($mergedMiddlewareNames),
+            'value' => array_values($mergedMiddlewareInstances),
+        ]);
         $operation->merge([$middleware]);
     }
 

--- a/src/Processors/MiddlewareCustomizers.php
+++ b/src/Processors/MiddlewareCustomizers.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras\Processors;
+
+use OpenApi\Analysis;
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
+use Radebatz\OpenApi\Extras\Annotations as OAX;
+use Radebatz\OpenApi\Extras\ProvidesCustomizersInterface;
+
+class MiddlewareCustomizers
+{
+    public function __invoke(Analysis $analysis): void
+    {
+        foreach ($analysis->getAnnotationsOfType(OA\Operation::class) as $operation) {
+            $middleware = $this->resolveMiddleware($operation);
+            if (!$middleware instanceof OAX\Middleware) {
+                continue;
+            }
+
+            if (Generator::isDefault($middleware->attachables)) {
+                continue;
+            }
+
+            foreach ($middleware->attachables as $attachable) {
+                if (!($attachable instanceof ProvidesCustomizersInterface)) {
+                    continue;
+                }
+
+                foreach ($attachable::customizers() as $annotationClass => $callables) {
+                    if (!($operation instanceof $annotationClass)) {
+                        continue;
+                    }
+                    foreach ($callables as $callable) {
+                        $callable($operation);
+                    }
+                }
+            }
+        }
+    }
+
+    protected function resolveMiddleware(OA\Operation $operation): ?OAX\Middleware
+    {
+        if (Generator::isDefault($operation->attachables)) {
+            return null;
+        }
+
+        foreach ($operation->attachables as $attachable) {
+            if ($attachable instanceof OAX\Middleware) {
+                return $attachable;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/ProvidesCustomizersInterface.php
+++ b/src/ProvidesCustomizersInterface.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras;
+
+use OpenApi\Annotations as OA;
+
+interface ProvidesCustomizersInterface
+{
+    /**
+     * @return array<class-string<OA\AbstractAnnotation>, callable[]>
+     */
+    public static function customizers(): array;
+}

--- a/tests/Fixtures/Controllers/Annotations/SecureController.php
+++ b/tests/Fixtures/Controllers/Annotations/SecureController.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras\Tests\Fixtures\Controllers\Annotations;
+
+use OpenApi\Annotations as OA;
+use Radebatz\OpenApi\Extras\Annotations as OAX;
+use Radebatz\OpenApi\Extras\Tests\Fixtures\Middleware\SecureMiddleware;
+
+/**
+ * @OAX\Controller(
+ *     @SecureMiddleware
+ * )
+ */
+class SecureController
+{
+    /**
+     * @OA\Get(
+     *     path="/secure",
+     *     operationId="secureEndpoint",
+     *     @OA\Response(response="200", description="All good")
+     * )
+     */
+    public function secure()
+    {
+        return 'secure';
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/also-secure",
+     *     operationId="alsoSecureEndpoint",
+     *     @OA\Response(response="200", description="All good")
+     * )
+     */
+    public function alsoSecure()
+    {
+        return 'also-secure';
+    }
+}

--- a/tests/Fixtures/Controllers/Attributes/SecureController.php
+++ b/tests/Fixtures/Controllers/Attributes/SecureController.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras\Tests\Fixtures\Controllers\Attributes;
+
+use OpenApi\Attributes as OAT;
+use Radebatz\OpenApi\Extras\Attributes as OAX;
+use Radebatz\OpenApi\Extras\Tests\Fixtures\Middleware\SecureMiddleware;
+
+#[OAX\Controller(middlewares: [new SecureMiddleware()])]
+class SecureController
+{
+    #[OAT\Get(path: '/secure', operationId: 'secureEndpoint')]
+    #[OAT\Response(response: 200, description: 'All good')]
+    public function secure()
+    {
+        return 'secure';
+    }
+
+    #[OAT\Get(path: '/also-secure', operationId: 'alsoSecureEndpoint')]
+    #[OAT\Response(response: 200, description: 'All good')]
+    public function alsoSecure()
+    {
+        return 'also-secure';
+    }
+}

--- a/tests/Fixtures/Middleware/SecureMiddleware.php
+++ b/tests/Fixtures/Middleware/SecureMiddleware.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras\Tests\Fixtures\Middleware;
+
+use OpenApi\Annotations as OA;
+use Radebatz\OpenApi\Extras\Attributes\Middleware;
+use Radebatz\OpenApi\Extras\ProvidesCustomizersInterface;
+
+/**
+ * @Annotation
+ */
+#[\Attribute(\Attribute::TARGET_ALL | \Attribute::IS_REPEATABLE)]
+class SecureMiddleware extends Middleware implements ProvidesCustomizersInterface
+{
+    public function __construct()
+    {
+        parent::__construct(names: ['jwt-auth']);
+    }
+
+    public static function customizers(): array
+    {
+        return [
+            OA\Operation::class => [
+                fn (OA\Operation $operation) => $operation->security = [['bearerAuth' => []]],
+            ],
+        ];
+    }
+}

--- a/tests/Fixtures/spec.yaml
+++ b/tests/Fixtures/spec.yaml
@@ -106,6 +106,18 @@ paths:
               description: 'Request ID'
               schema:
                 type: string
+  /secure:
+    get:
+      operationId: secureEndpoint
+      responses:
+        '200':
+          description: 'All good'
+  /also-secure:
+    get:
+      operationId: alsoSecureEndpoint
+      responses:
+        '200':
+          description: 'All good'
   /standalone/isolated:
     get:
       operationId: isolated

--- a/tests/Processors/MiddlewareCustomizersTest.php
+++ b/tests/Processors/MiddlewareCustomizersTest.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+namespace Radebatz\OpenApi\Extras\Tests\Processors;
+
+use OpenApi\Analysis;
+use OpenApi\Annotations as OA;
+use OpenApi\Context;
+use OpenApi\Generator;
+use OpenApi\Processors\AugmentParameters;
+use OpenApi\Processors\BuildPaths;
+use PHPUnit\Framework\TestCase;
+use Radebatz\OpenApi\Extras\Annotations as OAX;
+use Radebatz\OpenApi\Extras\Processors\MergeControllerDefaults;
+use Radebatz\OpenApi\Extras\Processors\MiddlewareCustomizers;
+use Radebatz\OpenApi\Extras\Tests\Concerns\Fixtures;
+use Symfony\Component\Finder\Finder;
+
+class MiddlewareCustomizersTest extends TestCase
+{
+    use Fixtures;
+
+    /**
+     * @dataProvider fixturesProvider
+     */
+    public function testSecurityAppliedFromMiddleware(Generator $generator, Finder $finder): void
+    {
+        $operation = $this->getOperation($generator, $finder, 'secureEndpoint');
+
+        $this->assertEquals([['bearerAuth' => []]], $operation->security);
+    }
+
+    /**
+     * @dataProvider fixturesProvider
+     */
+    public function testSecurityAppliedToAllControllerOperations(Generator $generator, Finder $finder): void
+    {
+        $operation = $this->getOperation($generator, $finder, 'alsoSecureEndpoint');
+
+        $this->assertEquals([['bearerAuth' => []]], $operation->security);
+    }
+
+    /**
+     * @dataProvider fixturesProvider
+     */
+    public function testMiddlewareStillAttached(Generator $generator, Finder $finder): void
+    {
+        $operation = $this->getOperation($generator, $finder, 'secureEndpoint');
+
+        $this->assertIsArray($operation->attachables);
+        $middleware = null;
+        foreach ($operation->attachables as $attachable) {
+            if ($attachable instanceof OAX\Middleware) {
+                $middleware = $attachable;
+                break;
+            }
+        }
+        $this->assertNotNull($middleware);
+        $this->assertContains('jwt-auth', $middleware->names);
+    }
+
+    /**
+     * @dataProvider fixturesProvider
+     */
+    public function testNoSecurityOnUnrelatedOperation(Generator $generator, Finder $finder): void
+    {
+        $operation = $this->getOperation($generator, $finder, 'mw');
+
+        $this->assertTrue(Generator::isDefault($operation->security));
+    }
+
+    protected function getOperation(Generator $generator, Finder $finder, string $operationId): OA\Operation
+    {
+        $generator->getProcessorPipeline()
+            ->insert(new MergeControllerDefaults(), BuildPaths::class)
+            ->insert(new MiddlewareCustomizers(), AugmentParameters::class);
+
+        $analysis = $generator
+            ->withContext(function (Generator $generator, Analysis $analysis, Context $context) use ($finder) {
+                $generator->generate($finder, $analysis);
+
+                return $analysis;
+            });
+
+        $operations = $analysis->getAnnotationsOfType(OA\Operation::class);
+        foreach ($operations as $operation) {
+            if ($operation->operationId === $operationId) {
+                return $operation;
+            }
+        }
+
+        $this->fail(sprintf('Operation "%s" not found', $operationId));
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `ProvidesCustomizersInterface` — middleware subclasses implement it to declare scoped OpenAPI modifications (e.g., auto-injecting `security` schemes)
- Adds `MiddlewareCustomizers` processor that applies customizers from implementing middlewares to their associated operations
- Preserves original typed middleware instances as nested attachables on the merged `Middleware`, enabling single-pass processing
- Cleans up Attributes: uses `OAX`/`OAT` aliases instead of FQCNs, removes redundant `attachables` key from `Middleware`

## Example

```php
#[\Attribute(\Attribute::TARGET_ALL | \Attribute::IS_REPEATABLE)]
class SecureMiddleware extends Middleware implements ProvidesCustomizersInterface
{
    public function __construct()
    {
        parent::__construct(names: ['jwt-auth']);
    }

    public static function customizers(): array
    {
        return [
            OA\Operation::class => [
                fn (OA\Operation $op) => $op->security = [['bearerAuth' => []]],
            ],
        ];
    }
}
```

Usage: `#[OAX\Controller(middlewares: [new SecureMiddleware()])]` — all operations get `security` applied automatically.

## Test plan

- [x] Security customizer applied to all operations in controller (annotations + attributes)
- [x] Unrelated operations not affected
- [x] Middleware names still accessible on merged middleware
- [x] Full test suite passes (55 tests)
- [x] PHPStan clean, CS/Rector clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)